### PR TITLE
get first parent pictogram if not defined

### DIFF
--- a/backend/project/api/serializers/observations.py
+++ b/backend/project/api/serializers/observations.py
@@ -16,6 +16,7 @@ from project.observations.models import (
 
 
 class ObservationCategorySerializer(serializers.ModelSerializer):
+    pictogram = serializers.FileField(source="inherited_pictogram", read_only=True)
 
     class Meta:
         model = ObservationCategory

--- a/backend/project/observations/models.py
+++ b/backend/project/observations/models.py
@@ -40,6 +40,14 @@ class ObservationCategory(TimeStampMixin, MP_Node):
     def children(self):
         return self.get_children()
 
+    @property
+    def inherited_pictogram(self):
+        """Return parent pictogram if current pictogram is empty."""
+        if not self.pictogram:
+            parent = self.get_ancestors().filter(pictogram__isnull=False).last()
+            return parent.pictogram if parent else None
+        return self.pictogram
+
     class Meta:
         verbose_name = _("Category")
         verbose_name_plural = _("Categories")

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,16 @@
 CHANGE LOG
 ==========
 
+1.0.12+dev
+----------
+
+**Improvements**
+
+- Category now return first parent pictogram available if not defined
+
+
 1.0.2    (2024-07-24)
-----------------------
+---------------------
 
 **Bugfix**
 
@@ -14,7 +22,7 @@ CHANGE LOG
 - improve UI
 
 1.0.1    (2024-07-24)
-----------------------
+---------------------
 
 **Improvements**
 


### PR DESCRIPTION
If sub category have no pictogram, pictogram returned by APi is this one available to first parent